### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,5 +416,5 @@ function plugin(initialOptions) {
 }
 
 // set plugin
-module.exports.postcss = true;
 module.exports = plugin;
+module.exports.postcss = true;


### PR DESCRIPTION
Set `...postcss = true` after exporting plugin

When using with `postcss-load-config` (i.e. from `postcss-cli`), the plugin is incorrectly loaded when using the non-require style

i.e. with:
```javascript
// file: postcss.config.js
module.exports = {
  plugins: {
    'postcss-font-magician': {},
    'autoprefixer': {}
  }
}
```

Because the object has no keys, this prevents the `plugin` function from being called...
https://github.com/postcss/postcss-load-config/blob/170ec7735f9c1df2f81b068988d81d351fead0a1/src/plugins.js#L18-L26

... and since the `postcss = true` is overwritten ...

https://github.com/postcss/postcss-load-config/blob/170ec7735f9c1df2f81b068988d81d351fead0a1/src/plugins.js#L63-L64

... is never called
